### PR TITLE
Adding code to generate envelopes

### DIFF
--- a/MEs_envs/MEs_2env_0.24_0.07_opt_v2.inp
+++ b/MEs_envs/MEs_2env_0.24_0.07_opt_v2.inp
@@ -1,0 +1,117 @@
+# ==========================================================================
+# INPUT FILE TO SETUP OCEAN MODELS                                         |
+#                                                                          |
+#     1. Envelopes for building MEs-coordinates                            |
+#     2. Transition area for passing from MEs- TO z-coordinates            |
+#                                                                          |
+# ------------------------------------------------------------------------ |     
+#                                                                          |
+#  SKETCH of the GEOMETRY OF THE MEs-COORD. SYSTEM                         |
+#  (example configuration using 3 envelopes)                               |
+#                                                                          |
+#  Lines represent W-levels:                                               |
+#                                                                          |
+#  0: 1st s-level part. The total number                                   |
+#     of levels in this part is controlled                                 |
+#     by the nn_slev[0] parameter.                                         |
+#                                                                          |
+#     Depth first W-lev: 0 m (surfcace)                                    |
+#     Depth last  W-lev: depth of 1st envelope                             |
+#                                                                          |
+#  o: 2nd s-level part. The total number                                   |
+#     of levels in this part is controlled                                 |
+#     by the nn_slev[1] parameter.                                         |
+#                                                                          |
+#     Depth last  W-lev: depth of 2nd envelope                             |
+#                                                                          |
+#  @: 3rd s-level part. The total number                                   |
+#     of levels in this part is controlled                                 |
+#     by the nn_slev[2] parameter.                                         |
+#                                                                          |
+#     Depth last  W-lev: depth of 3rd envelope                             |
+#                                                                          |
+#     z |~~~~~~~~~~~~~~~~~~~~~~~0~~~~~~~~~~~~~~~~~~~~~~~   SURFACE         |        
+#       |                                                                  |
+#       |-----------------------0-----------------------   nn_slev[0] = 3  |
+#       |                                                                  |
+#       |=======================0=======================   ENVELOPE 1      |
+#       |                                                                  |
+#       |-----------------------o-----------------------                   |
+#       |                                                  nn_slev[1] = 3  |
+#       |-----------------------o-----------------------                   |
+#       |                                                                  |
+#       |¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬o¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬¬   ENVELOPE 2      |
+#       |                                                                  |
+#       |-----------------------@-----------------------   nn_slev[2] = 2  |
+#       |                                                                  |
+#       |_______________________@_______________________   ENVELOPE 3      |
+#       |                                                                  |
+#       V                                                                  |
+#                                                                          |
+#       Reference :                                                        |
+#       Bruciaferri et al., 2018. Oc. Dyn., doi: 10.1007/s10236-018-1189-x |
+#  -------------------------------------------------------------------------------------------
+#
+#                                                                       |
+# =======================================================================
+
+# A) IINPUT FILES
+
+# Bathymetry of the domain
+bathyFile = '/data/users/dbruciaf/JMMP_HPGE/amm7_ancil/ps43.bathy_meter.nc'
+
+# Horizontal grid of the domain
+hgridFile = '/data/users/dbruciaf/JMMP_HPGE/amm7_ancil/ps43.coordinates.nc'
+
+# B) ENVELOPES geometrical parameters -------------------------------------
+
+# *) e_min_ofs[i] is the offset to be added to the previous envelope env[i-1]
+#    in order to calcalute the minimum depths of the new envelope.
+#
+# *) To create a flat envelope env[i] with constant depth e_max_dep[i]:                                   
+#
+#    e_min_ofs[i] = -1, e_max_dep[i] > 0                                
+#                                                                    
+# *) To create an envelope env[0] which will generate classical s-levels:             
+#
+#    e_min_dep[i] > 0, e_max_dep[i] = -1                                
+#
+# *) To create a totally flat envelope env[0] which will generate classical 
+#    z-levels: 
+#
+#    e_min_dep[i] = -1, e_max_dep[i] = -1                               
+#
+# *) To have an envelope terrain-following in coastal areas but flat in the 
+#    ocean interior:
+#
+#    e_oce_int[i] = false 
+
+e_min_ofs = [  10. , 150.]
+e_max_dep = [ 250. ,  -1 ]
+
+# C) ENVELOPES smoothing parameters ------------------------------------------
+
+# 1. LOCAL SMOOTHING 
+
+# List of lists of velocity files to use for HPGE aware local smoothing.   
+# Use an empty list if you don't want to apply local smoothing to a particular envelope.
+e_loc_vel = [ [], 
+              ['/data/users/dbruciaf/mod_dev/jmmp_MEs/amm7_mes_vgrid/MEs_2env_0.1_0.07_opt_v1/20140108_shelftmb_grid_U.nc',
+               '/data/users/dbruciaf/mod_dev/jmmp_MEs/amm7_mes_vgrid/MEs_2env_0.1_0.07_opt_v1/20140108_shelftmb_grid_V.nc'], 
+            ]
+e_loc_var = [ [], ['vozocrtx','vomecrty'] ]
+
+# Value of spurious currents that will be used as a threshold
+e_loc_vmx = [ 0., 0.1 ]
+
+# List of max slope parameters rx0 for local smoothing. 
+e_loc_rmx = [ 0, 0.04 ]
+
+# List of halo for applying the local smoothing.
+e_loc_hal = [ 0, 3 ]  
+
+# 2. GLOBAL SMOOTHING
+
+# List of Maximum slope parameter rx0 of each envelope
+e_glo_rmx = [ 0.24, 0.07]   
+

--- a/MEs_envs/MEs_2env_0.24_0.07_opt_v2.inp
+++ b/MEs_envs/MEs_2env_0.24_0.07_opt_v2.inp
@@ -2,7 +2,6 @@
 # INPUT FILE TO SETUP OCEAN MODELS                                         |
 #                                                                          |
 #     1. Envelopes for building MEs-coordinates                            |
-#     2. Transition area for passing from MEs- TO z-coordinates            |
 #                                                                          |
 # ------------------------------------------------------------------------ |     
 #                                                                          |
@@ -55,7 +54,7 @@
 #                                                                       |
 # =======================================================================
 
-# A) IINPUT FILES
+# A) INPUT FILES
 
 # Bathymetry of the domain
 bathyFile = '/data/users/dbruciaf/JMMP_HPGE/amm7_ancil/ps43.bathy_meter.nc'
@@ -68,7 +67,7 @@ hgridFile = '/data/users/dbruciaf/JMMP_HPGE/amm7_ancil/ps43.coordinates.nc'
 # *) e_min_ofs[i] is the offset to be added to the previous envelope env[i-1]
 #    in order to calcalute the minimum depths of the new envelope.
 #
-# *) To create a flat envelope env[i] with constant depth e_max_dep[i]:                                   
+# *) To create a flat envelope env[i] with constant depth e_max_dep[i]:
 #
 #    e_min_ofs[i] = -1, e_max_dep[i] > 0                                
 #                                                                    
@@ -80,11 +79,6 @@ hgridFile = '/data/users/dbruciaf/JMMP_HPGE/amm7_ancil/ps43.coordinates.nc'
 #    z-levels: 
 #
 #    e_min_dep[i] = -1, e_max_dep[i] = -1                               
-#
-# *) To have an envelope terrain-following in coastal areas but flat in the 
-#    ocean interior:
-#
-#    e_oce_int[i] = false 
 
 e_min_ofs = [  10. , 150.]
 e_max_dep = [ 250. ,  -1 ]

--- a/MEs_envs/generate_envelopes.py
+++ b/MEs_envs/generate_envelopes.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python
+
+#     |------------------------------------------------------------|
+#     | This module creates general envelope surfaces to be        |
+#     | used to generate a Multi-Envelope s-coordinate             |
+#     | vertical grid.                                             |
+#     |                                                            |
+#     |                                                            |
+#     |                      -o#&&*''''?d:>b\_                     |
+#     |                 _o/"`''  '',, dMF9MMMMMHo_                 |
+#     |              .o&#'        `"MbHMMMMMMMMMMMHo.              |
+#     |            .o"" '         vodM*$&&HMMMMMMMMMM?.            |
+#     |           ,'              $M&ood,~'`(&##MMMMMMH\           |
+#     |          /               ,MMMMMMM#b?#bobMMMMHMMML          |
+#     |         &              ?MMMMMMMMMMMMMMMMM7MMM$R*Hk         |
+#     |        ?$.            :MMMMMMMMMMMMMMMMMMM/HMMM|`*L        |
+#     |       |               |MMMMMMMMMMMMMMMMMMMMbMH'   T,       |
+#     |       $H#:            `*MMMMMMMMMMMMMMMMMMMMb#}'  `?       |
+#     |       ]MMH#             ""*""""*#MMMMMMMMMMMMM'    -       |
+#     |       MMMMMb_                   |MMMMMMMMMMMP'     :       |
+#     |       HMMMMMMMHo                 `MMMMMMMMMT       .       |
+#     |       ?MMMMMMMMP                  9MMMMMMMM}       -       |
+#     |       -?MMMMMMM                  |MMMMMMMMM?,d-    '       |
+#     |        :|MMMMMM-                 `MMMMMMMT .M|.   :        |
+#     |         .9MMM[                    &MMMMM*' `'    .         |
+#     |          :9MMk                    `MMM#"        -          |
+#     |            &M}                     `          .-           |
+#     |             `&.                             .              |
+#     |               `~,   .                     ./               |
+#     |                   . _                  .-                  |
+#     |                     '`--._,dd###pp=""'                     |
+#     |                                                            |
+#     |                                                            |
+#     | Author: Diego Bruciaferri                                  |
+#     | Date and place: 26-07-2021, Met Office, UK                 |
+#     |------------------------------------------------------------|
+
+
+import sys
+import os
+from os.path import isfile, basename, splitext
+import numpy as np
+from matplotlib import pyplot as plt
+import xarray as xr
+
+from lib_env import *
+
+# ==============================================================================
+# 1. Checking for input files
+# ==============================================================================
+
+msg_info('GRID ENVELOPES GENERATOR', main=True)
+
+# Checking input file for envelopes
+if len(sys.argv) != 2:
+   raise TypeError(
+         'You need to specify the absolute path of the envelopes input file'
+   )
+
+# Reading envelopes infos
+env_file = sys.argv[1]
+msg_info('Reading envelopes parameters ....')
+envInfo = read_envInfo(env_file)
+
+# Reading bathymetry and horizontal grid
+msg_info('Reading bathymetry data ... ')
+ds_bathy = xr.open_dataset(envInfo.bathyFile).squeeze()
+bathy = ds_bathy["Bathymetry"].squeeze()
+
+msg_info('Reading horizontal grid data ... ')
+ds_grid = xr.open_dataset(envInfo.hgridFile) 
+glamt = ds_grid["glamt"]
+gphit = ds_grid["gphit"]
+
+ds_env = ds_bathy.copy()
+
+# Defining local variables -----------------------------------------------------
+
+num_env = len(envInfo.e_min_ofs)
+ni      = glamt.shape[1]
+nj      = glamt.shape[0]
+
+e_min_ofs = envInfo.e_min_ofs
+e_max_dep = envInfo.e_max_dep
+e_loc_vel = envInfo.e_loc_vel
+e_loc_var = envInfo.e_loc_var
+e_loc_vmx = envInfo.e_loc_vmx
+e_loc_rmx = envInfo.e_loc_rmx
+e_loc_hal = envInfo.e_loc_hal
+e_glo_rmx = envInfo.e_glo_rmx
+
+# Computing LSM
+lsm = xr.where(bathy > 0, 1, 0) 
+
+#--------------------------------------------------------------------------------------
+# Cretaing envelopes
+for env in range(num_env):
+
+    msg = 'ENVELOPE ' + str(env) + ': min_ofs = '+ str(e_min_ofs[env]) + \
+          ', max_dep = ' + str(e_max_dep[env]) + ', glo_rmx = ' + str(e_glo_rmx[env])
+    msg_info(msg, main=True)
+
+    env_bathy = bathy.copy()
+
+    # =============================================================
+    # 1. GEOMETRY of the envelope
+    #
+    # e_min_ofs[env] > 0: offset to be added to surf to comupute 
+    #                     minimum depth of envelope env
+    # e_min_ofs[env] < 0: e_min_ofs[env] is equal to e_max_dep[env]
+    # e_max_dep[env] < 0: e_max_dep[env] = np.amax(bathy)
+
+    msg = '1. Computing the geometry of the envelope'
+    msg_info(msg)
+    
+    if env == 0:
+       # For the first envelope, the upper envelope 
+       # is the ocean surface at rest
+       surf = xr.full_like(bathy,0.,dtype=np.double)
+    else:
+       # For deeper envelopes, the upper 
+       # envelope is the previous envelope
+       surf = ds_env["hbatt_"+str(env)]
+
+    if e_max_dep[env] < 0.: e_max_dep[env] = np.nanmax(bathy)
+
+    # CASE A flat envelope
+    if e_min_ofs[env] < 0.:                     
+       msg = 'Generating a flat envelope'
+       msg_info(msg)
+       hbatt = xr.full_like(bathy,e_max_dep[env],dtype=np.double)
+       
+    # CASE B general envelope
+    else:
+       hbatt = calc_zenv(env_bathy, surf, e_min_ofs[env], e_max_dep[env])  
+ 
+    # For the first envelope, we follow NEMO approach
+    #if env == 0:
+    #   hbatt *= lsm
+
+    hbatt.plot.pcolormesh(add_colorbar=True, add_labels=True, \
+                          cbar_kwargs=dict(pad=0.15, shrink=1, \
+                          label='Envelope '+ str(env)))
+
+    plt.show()
+    # =============================================================
+    # 2. SMOOTHING the envelope
+  
+    msg = '2. Smoothing the envelope'
+    msg_info(msg)  
+
+    # Computing then MB06 Slope Parameter for the raw envelope
+    rmax_raw = np.amax(calc_rmax(hbatt)*lsm).values
+    msg = '   Slope parameter of raw envelope: rmax = ' + str(rmax_raw)
+    msg_info(msg)
+
+    if len(e_loc_vel[env]) == 0:
+       hbatt_smt = hbatt.copy()
+    else:
+       # LOCAL SMOOTHING
+       hal = e_loc_hal[env]
+       r0x = e_loc_rmx[env]
+       msg = ("   Local smoothing of areas of the raw" +\
+              " envelope where HPGE > " + str(e_loc_vmx[env]) + " m/s\n"+\
+              "   Envelope  : " + str(env) + "\n"+\
+              "   Local rmax: " + str(r0x) + "\n"+\
+              "   Local halo: " + str(hal) + " cells")
+       msg_info(msg)
+              
+       env_tmp = hbatt.copy()
+       msk_pge = env_tmp.copy()*0.
+ 
+       for m in range(len(e_loc_vel[env])):
+
+           filename = e_loc_vel[env][m]
+           varname  = e_loc_var[env][m]
+           ds_vel = xr.open_dataset(filename)
+           hpge = ds_vel[varname].data
+
+           # TO DO: optimise it, 
+           # we don't need this loop
+           nt = hpge.shape[0]
+           nj = hpge.shape[2]
+           ni = hpge.shape[3]
+           for t in range(nt):
+               for j in range(nj):
+                   for i in range(ni):
+                       max_hpge = np.nanmax(hpge[t,:,j,i])
+                       if max_hpge >= r0x:
+                          msk_pge[j-hal:j+hal+1,i-hal:i+hal+1] = 1
+                          
+       msg = '   Total number of points with HPGE > ' + str(e_loc_vmx[env]) + ' m/s: ' + str(np.nansum(msk_pge)) 
+       msg_info(msg,)
+
+       msk_pge.plot.pcolormesh(add_colorbar=True, add_labels=True, \
+                               cbar_kwargs=dict(pad=0.15, shrink=1, \
+                               label='HPGE smoothing mask'))
+       plt.show()
+
+       # smoothing with Martinho & Batteen 2006 
+       env_wrk = smooth_MB06(env_tmp, e_loc_rmx[env])
+       
+       # applying smoothing only where HPGE are large
+       WRK = env_wrk.data
+       TMP = env_tmp.data
+       WRK[msk_pge==0] = TMP[msk_pge==0]
+       hbatt_smt.data = WRK
+
+    # GLOBAL SMOOTHING
+    if e_glo_rmx[env] > 0:
+
+       msg = ('   Global smoothing of the raw envelope')
+       msg_info(msg)
+
+       #da_wrk = hbatt_smt.copy()
+       #env_wrk = np.copy(hbatt_smt.data)
+
+       if env == 0:
+          # for the first envelope, we follow NEMO approach
+          # set first land point adjacent to a wet cell to
+          # min_dep as this needs to be included in smoothing
+          cst_lsm = lsm.rolling({dim: 3 for dim in lsm.dims}, min_periods=2).sum()
+          cst_lsm = cst_lsm.shift({dim: -1 for dim in lsm.dims})
+          cst_lsm = (cst_lsm > 0) & (lsm == 0)
+          da_wrk = hbatt_smt.where(cst_lsm == 0, e_min_ofs[env])
+       else:
+          da_wrk = hbatt_smt.copy()
+
+       # smoothing with Martinho & Batteen 2006 
+       hbatt_smt = smooth_MB06(da_wrk, e_glo_rmx[env])#, tol=2.5e-8)
+
+    # Computing then MB06 Slope Parameter for the smoothed envelope
+    rmax_smt = calc_rmax(hbatt_smt)*lsm
+    rmax_smt.plot.pcolormesh(add_colorbar=True, add_labels=True, \
+                                cbar_kwargs=dict(pad=0.15, shrink=1, \
+                                label='Slope parameter'))
+    plt.show()
+    rmax_smt = np.amax(rmax_smt).data
+    msg = '   Slope parameter of smoothed envelope: rmax = ' + str(rmax_smt)
+    msg_info(msg)
+
+    # Saving envelope DataArray
+    ds_env["hbatt_"+str(env+1)] = hbatt_smt
+
+# -------------------------------------------------------------------------------------   
+# Writing the bathy_meter.nc file
+
+msg = 'WRITING the bathy_meter.nc FILE'
+msg_info(msg)
+
+out_name = splitext(basename(env_file))[0] 
+
+out_file = "bathymetry." + out_name + ".nc"
+
+ds_env.to_netcdf(out_file)
+

--- a/MEs_envs/lib_env.py
+++ b/MEs_envs/lib_env.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+
+from typing import Tuple
+import numpy as np
+import netCDF4 as nc4
+import xarray as xr
+from xarray import Dataset, DataArray 
+
+#=======================================================================================
+def read_envInfo(filepath):
+    '''
+    This function reads the parameters which will be used
+    to generate the model grid envelopes.
+
+    If the file is not in the right format and does not contain
+    all the needed infos an error message is returned.
+
+    filepath: string
+    '''
+
+    import importlib.machinery as imp
+
+    loader  = imp.SourceFileLoader(filepath,filepath)
+    envInfo = loader.load_module()
+
+    attr = ['bathyFile', 'hgridFile', \
+            'e_min_ofs', 'e_max_dep', \
+            'e_loc_vel', 'e_loc_var', 'e_loc_vmx', \
+            'e_loc_rmx', 'e_loc_hal', 'e_glo_rmx']
+
+    errmsg = False
+    for a in attr:
+        if not hasattr(envInfo,a):
+           errmsg = True
+           attrerr = a
+        else:
+           if getattr(envInfo,a) == "":
+              errmsg = True
+              attrerr = a
+
+    if errmsg: 
+       raise AttributeError(
+             'Attribute ' + attrerr + ' is missing'
+       )
+
+    return envInfo
+
+#=======================================================================================
+def calc_zenv(bathy, surf, offset, max_dep):
+    """
+    Constructs an envelop bathymetry 
+    for the sigma levels definition.
+       
+    INPUT:
+    *) bathy: the bathymetry field which will be 
+              used to compute the envelope.
+    *) surf:  2D field used as upper surface to model 
+              the envelope
+    *) offset: offset to be added to surf to calc 
+               the minimum depth of the envelope.
+
+    *) max_depth : maximum depth of the envelope.
+    """
+
+    zenv   = bathy.copy()
+    env_up = surf.copy()
+
+    # Set maximum depth of the envelope
+    zenv = np.minimum(zenv, max_dep)
+
+    # Set minimum depth of the envelope
+    env_up += offset
+    zenv = np.maximum(zenv, env_up)
+
+    return zenv
+
+#=======================================================================================
+def calc_rmax(depth: DataArray) -> DataArray:
+    """
+    Calculate rmax: measure of steepness
+    This function returns the slope paramater field
+
+    r = abs(Hb - Ha) / (Ha + Hb)
+
+    where Ha and Hb are the depths of adjacent grid cells (Mellor et al 1998).
+
+    Reference:
+    *) Mellor, Oey & Ezer, J Atm. Oce. Tech. 15(5):1122-1131, 1998.
+
+    Parameters
+    ----------
+    depth: DataArray
+        Bottom depth (units: m).
+
+    Returns
+    -------
+    DataArray
+        2D slope parameter (units: None)
+
+    Notes
+    -----
+    This function uses a "conservative approach" and rmax is overestimated.
+    rmax at T points is the maximum rmax estimated at any adjacent U/V point.
+    """
+    # Mask land
+    depth = depth.where(depth > 0)
+
+    # Loop over x and y
+    both_rmax = []
+    for dim in depth.dims:
+
+        # Compute rmax
+        rolled = depth.rolling({dim: 2}).construct("window_dim")
+        diff = rolled.diff("window_dim").squeeze("window_dim")
+        rmax = np.abs(diff) / rolled.sum("window_dim")
+
+        # Construct dimension with velocity points adjacent to any T point
+        # We need to shift as we rolled twice
+        rmax = rmax.rolling({dim: 2}).construct("vel_points")
+        rmax = rmax.shift({dim: -1})
+
+        both_rmax.append(rmax)
+
+    # Find maximum rmax at adjacent U/V points
+    rmax = xr.concat(both_rmax, "vel_points")
+    rmax = rmax.max("vel_points", skipna=True)
+
+    # Mask halo points
+    for dim in rmax.dims:
+        rmax[{dim: [0, -1]}] = 0
+
+    return rmax.fillna(0)
+
+#=======================================================================================
+def smooth_MB06(
+    depth: DataArray,
+    rmax: float,
+    tol: float = 1.0e-8,
+    max_iter: int = 10_000,
+) -> DataArray:
+    """
+    Direct iterative method of Martinho and Batteen (2006) consistent
+    with NEMO implementation.
+
+    The algorithm ensures that
+
+                H_ij - H_n
+                ---------- < rmax
+                H_ij + H_n
+
+    where H_ij is the depth at some point (i,j) and H_n is the
+    neighbouring depth in the east, west, south or north direction.
+
+    Reference:
+    *) Martinho & Batteen, Oce. Mod. 13(2):166-175, 2006.
+
+    Parameters
+    ----------
+    depth: DataArray
+        Bottom depth.
+    rmax: float
+        Maximum slope parameter allowed
+    tol: float, default = 1.0e-8
+        Tolerance for the iterative method
+    max_iter: int, default = 10000
+        Maximum number of iterations
+
+    Returns
+    -------
+    DataArray
+        Smooth version of the bottom topography with
+        a maximum slope parameter < rmax.
+    """
+
+    # Set scaling factor used for smoothing
+    zrfact = (1.0 - rmax) / (1.0 + rmax)
+
+    # Initialize envelope bathymetry
+    zenv = depth
+
+    for _ in range(max_iter):
+
+        # Initialize lists of DataArrays to concatenate
+        all_ztmp = []
+        all_zr = []
+        for dim in zenv.dims:
+
+            # Shifted arrays
+            zenv_m1 = zenv.shift({dim: -1})
+            zenv_p1 = zenv.shift({dim: +1})
+
+            # Compute zr
+            zr = (zenv_m1 - zenv) / (zenv_m1 + zenv)
+            zr = zr.where((zenv > 0) & (zenv_m1 > 0), 0)
+            for dim_name in zenv.dims:
+                zr[{dim_name: -1}] = 0
+            all_zr += [zr]
+
+            # Compute ztmp
+            zr_p1 = zr.shift({dim: +1})
+            all_ztmp += [zenv.where(zr <= rmax, zenv_m1 * zrfact)]
+            all_ztmp += [zenv.where(zr_p1 >= -rmax, zenv_p1 * zrfact)]
+
+        # Update envelope bathymetry
+        zenv = xr.concat([zenv] + all_ztmp, "dummy_dim").max("dummy_dim")
+
+        # Check target rmax
+        zr = xr.concat(all_zr, "dummy_dim")
+        #print(np.nanmax(np.abs(zr)))
+        if ((np.abs(zr) - rmax) <= tol).all():
+            return zenv
+
+    raise ValueError(
+        "Iterative method did NOT converge."
+        " You might want to increase the number of iterations and/or the tolerance."
+        " The maximum slope parameter rmax is " + str(np.nanmax(np.abs(zr)))
+    )
+
+#=======================================================================================
+def msg_info(message,main=False):
+
+    if main:
+       print('')
+       print('='*76)
+       print(' '*11 + message)
+       print('='*76)
+    else:
+       print(message)
+    print('')
+


### PR DESCRIPTION
This PR will add the code to generate the envelopes for a MEs-coordinate system. 

The file has to be used as follow:

```
python generate_envelopes.py MEs_2env_0.24_0.07_opt_v2.inp 
```

where **python** is pyhton3 and **MEs_2env_0.24_0.07_opt_v2.inp** is the input configuration file. 

This code is able to replicate the envelopes used to configure the JMMP-AMM7 domain_cfg_MEs_L51_r24-07_opt_v2.nc file.